### PR TITLE
Integrate routes and policy checks for full skypilot launch flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ serverless-gcp-skydentity/certs/CA_dir/*
 serverless-gcp-skydentity/certs/domain_dir/*
 serverless-gcp-skydentity/certs/configs/domain.ext
 serverless-gcp-skydentity/certs/configs/domain.cnf
-serverless-gcp-skydentity/tokens/*
 serverless-gcp-skydentity/skyid/*
 serverless-gcp-skydentity/gcloud/*
 serverless-gcp-skydentity/__pycache__/*
@@ -12,3 +11,6 @@ gcp-env
 **.vscode
 **.egg-info
 __pycache__
+
+tokens
+local_tokens

--- a/examples/skypilot/config/skypilot_eval.yaml
+++ b/examples/skypilot/config/skypilot_eval.yaml
@@ -1,0 +1,18 @@
+virtual_machine:
+  cloud_provider:
+    - gcp
+  actions:
+    - ALL
+  regions:
+    - gcp:
+        - us-west1-b
+  instance_type:
+    - gcp:
+        - n1-standard-1
+  allowed_images:
+    - gcp:
+        - debian-10-buster-v20240110
+attached_authorizations:
+  - gcp:
+      - authorization:
+          - placeholder

--- a/examples/skypilot/config/skypilot_eval_readonly.yaml
+++ b/examples/skypilot/config/skypilot_eval_readonly.yaml
@@ -1,0 +1,18 @@
+virtual_machine:
+  cloud_provider:
+    - gcp
+  actions:
+    - READ
+  regions:
+    - gcp:
+        - us-west1-b
+  instance_type:
+    - gcp:
+        - n1-standard-1
+  allowed_images:
+    - gcp:
+        - debian-10-buster-v20240110
+attached_authorizations:
+  - gcp:
+      - authorization:
+          - placeholder

--- a/examples/skypilot/skypilot_launch.yaml
+++ b/examples/skypilot/skypilot_launch.yaml
@@ -1,0 +1,13 @@
+resources:
+  cloud: gcp
+  # restrict zone
+  zone: us-west1-b
+
+  image_id: projects/debian-cloud/global/images/debian-10-buster-v20240213
+  instance_type: n1-standard-1
+
+setup: |
+  echo "Setup task"
+
+run: |
+  echo "Run task"

--- a/skydentity/policies/checker/policy_actions.py
+++ b/skydentity/policies/checker/policy_actions.py
@@ -1,23 +1,30 @@
 import enum
 
+
 class PolicyAction(enum.Enum):
     """
     An action that can be taken on a resource.
     """
+
     CREATE = "CREATE"
     READ = "READ"
     DELETE = "DELETE"
+    WRITE = "WRITE"
     ALL = "ALL"
 
-    def is_allowed_be_performed(self, permission_action: 'PolicyAction') -> bool:
+    def is_allowed_be_performed(self, permission_action: "PolicyAction") -> bool:
         """
         Determines whether a requested action is allowed by a permission action.
         """
         if permission_action == PolicyAction.ALL or self == permission_action:
             return True
-        
-        if self == PolicyAction.READ and \
-            (permission_action == PolicyAction.DELETE or permission_action == PolicyAction.CREATE):
+
+        if self == PolicyAction.READ and (
+            permission_action == PolicyAction.DELETE
+            or permission_action == PolicyAction.CREATE
+            or permission_action == PolicyAction.WRITE
+        ):
             return True
-        
+
         return False
+

--- a/skydentity/scripts/send_auth_request.py
+++ b/skydentity/scripts/send_auth_request.py
@@ -87,4 +87,3 @@ def main():
 
 if __name__== "__main__":
     main()
-


### PR DESCRIPTION
Added config files for `sky launch` in the `examples` directory.

To fully integrate the `sky launch` flow, some modifications were also made to policy checking for `setLabels` calls, and modifications were also made to routing for requests to public images. Further, since the VM creation requests sent by SkyPilot include more request data than originally expected, the policy resource type checks were modified to only label a request as unrecognized if none of the request data keys are known.